### PR TITLE
Adding a line to make api ignore other files besides

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
         'dev': ['flake8', 'wheel', 'twine'],
         'test': [
             'mock',
-            'pytest>=3.6',
+            'pytest>=5.4',
             'pytest-mock',
             'pytest-cov',
             'coverage>=4.2',

--- a/src/pygrambank/api.py
+++ b/src/pygrambank/api.py
@@ -21,7 +21,7 @@ class Grambank(API):
 
     def iter_sheets(self):
         for p in sorted(self.sheets_dir.iterdir(), key=lambda i: i.stem):
-            if p.is_file() and len(p.name) >= 4 and p.name[-4:] == '.tsv':
+            if p.is_file() and p.name not in ['.gitattributes', '.DS_Store']:
                 yield Sheet(p)
 
     @property

--- a/src/pygrambank/api.py
+++ b/src/pygrambank/api.py
@@ -22,7 +22,6 @@ class Grambank(API):
     def iter_sheets(self):
         for p in sorted(self.sheets_dir.iterdir(), key=lambda i: i.stem):
             if p.is_file() and len(p.name) >= 4 and p.name[-4:] == '.tsv':
-                print(p.name)
                 yield Sheet(p)
 
     @property

--- a/src/pygrambank/api.py
+++ b/src/pygrambank/api.py
@@ -21,7 +21,8 @@ class Grambank(API):
 
     def iter_sheets(self):
         for p in sorted(self.sheets_dir.iterdir(), key=lambda i: i.stem):
-            if p.is_file() and p.name != '.gitattributes':
+            if p.is_file() and len(p.name) >= 4 and p.name[-4:] == '.tsv':
+                print(p.name)
                 yield Sheet(p)
 
     @property


### PR DESCRIPTION
I'd like for api.py to not just ignore 'gitattributes' when it passes things onto sheet.py but also other files like the ".DS_store" that Mac os creates. I think this change accomplishes this.