### PR TITLE
Example extraction

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
     - uses: actions/checkout@v4

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -129,6 +129,9 @@ def is_coda(igt):
     return len(igt) == 1 and len(igt[0]) > 0 and igt[0][0] == '(' and igt[-1][-1] == ')'
 
 
+NotIGT = namedtuple('NotIGT', 'feature_id language_id')
+
+
 class ExampleParser:
     """Parser for extracting glossed examples from markdown.
 

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -202,7 +202,7 @@ class ExampleParser:
     def parse_description(self, feature_id, description):
         """Return examples in markdown description."""
         self._reset_state()
-        self.lines = description.strip().splitlines()
+        self.lines = unicodedata.normalize('NFKC', description).strip().splitlines()
         line = None
         _, err = self._skip_to(
             lambda ln: ln == '## Examples',

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -2,6 +2,7 @@ import unicodedata
 from collections import defaultdict, namedtuple
 from itertools import zip_longest
 
+# TODO: DOCSTRINGS EVERYWHERE
 
 class ParseError(namedtuple('ParseError', 'msg')):
     def __str__(self):
@@ -24,6 +25,77 @@ def render_gloss(analyzed_word, gloss):
         '  '.join(gl.ljust(w) for w, gl in zip(widths, gloss)))
 
 
+# Line arrangement
+#
+# Use the lines from the text to fill fields like Primary_Text or Analyzed_Word.
+# This needs some work because some examples have different numbers of lines and
+# those lines mean different things in different examples, think e.g.
+#
+# (a)  Plural in German:
+#      alle  Menschen
+#      all   humans
+#      ‘all humans’
+#
+# vs
+#
+# (b)  alle Menschen
+#      all-e   Mensch-en
+#      all-PL  human-PL
+#      ‘all humans’
+
+class DefaultArranger:
+    @classmethod
+    def is_applicable(cls, feature_id, language_id):
+        """Return True iff. this arranger is supposed to be used."""
+        return True
+
+    def __init__(self, feature_id, language_id, igt):
+        """Accept igt."""
+        self.feature_id = feature_id
+        self.language_id = language_id
+        self.igt = self.fix_igt(igt)
+
+    def error(self):
+        """Return error message if IGT is invalid."""
+        # TODO: check for * (do we want ungrammatical examples?)
+        if len(self.igt) != 2:
+            return "IGT doesn't have exactly 2 lines"
+        else:
+            return None
+
+    def fix_igt(self, igt):
+        """Reshape the IGT before saving it."""
+        return igt
+
+    def primary_text(self):
+        """Extract primary text from IGT."""
+        return ' '.join(self.igt[0].split())
+
+    def analyzed_word(self):
+        """Extract analyzed word from IGT."""
+        return self.igt[0].split()
+
+    def gloss(self):
+        """Extract gloss from IGT."""
+        return self.igt[1].split()
+
+
+def arrange_example_lines(
+    line_arrangers, language_id, feature_id, example_lineno, igt
+):
+    for cls in line_arrangers:
+        if cls.is_applicable(feature_id, language_id):
+            arranger_cls = cls
+            break
+    else:
+        arranger_cls = DefaultArranger
+    arranger = arranger_cls(feature_id, language_id, igt)
+    if (msg := arranger.error()):
+        return None, ParseError(f'{feature_id}:{example_lineno}:{language_id}: {msg}')
+    else:
+        return arranger, None
+
+
 # Transformation rules to fix misaligned glosses
 #
 # These rules apply after an example has been successfully parsed.  They can
@@ -38,7 +110,7 @@ class MalformedRule(Exception):
     pass
 
 
-def apply_rule_iter(items, rule):
+def apply_rule_iter(rule, items):
     index = 0
     while index < len(items):
         rule_index = 0
@@ -56,10 +128,10 @@ def apply_rule_iter(items, rule):
             index += 1
 
 
-def apply_rule(items, rule):
+def apply_rule(rule, items):
     if not rule.lhs:
         raise MalformedRule('Left-hand-side of a transformation rule must not be empty')
-    return list(apply_rule_iter(items, rule))
+    return list(apply_rule_iter(rule, items))
 
 
 def fix_glosses(example, rules):
@@ -72,9 +144,9 @@ def fix_glosses(example, rules):
         return
     for rule in rules:
         if analyzed_word:
-            analyzed_word = apply_rule(analyzed_word, rule)
+            analyzed_word = apply_rule(rule, analyzed_word)
         if gloss:
-            gloss = apply_rule(gloss, rule)
+            gloss = apply_rule(rule, gloss)
     example['Analyzed_Word'] = analyzed_word
     example['Gloss'] = gloss
 

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -1,0 +1,46 @@
+from collections import namedtuple
+
+
+# Rule system for fixing misaligned glosses
+
+GlossRule = namedtuple('GlossRule', 'pred lhs rhs')
+
+
+def apply_rule_iter(items, rule):
+    assert len(rule.lhs) > 0, 'cowardly refusing to materialize items out of thin air'
+    index = 0
+    while index < len(items):
+        rule_index = 0
+        while (
+            rule_index < len(rule.lhs)
+            and index + rule_index < len(items)
+            and items[index+rule_index] == rule.lhs[rule_index]
+        ):
+            rule_index += 1
+        if rule_index == len(rule.lhs):
+            yield from rule.rhs
+            index += rule_index
+        else:
+            yield items[index]
+            index += 1
+
+
+def apply_rule(items, rule):
+    return list(apply_rule_iter(items, rule))
+
+
+def fix_glosses(example, rules):
+    rules = [rule for rule in rules if rule.pred(example)]
+    if not rules:
+        return
+    analyzed_word = example.get('Analyzed_Word')
+    gloss = example.get('Gloss')
+    if not analyzed_word and not gloss:
+        return
+    for rule in rules:
+        if analyzed_word:
+            analyzed_word = apply_rule(analyzed_word, rule)
+        if gloss:
+            gloss = apply_rule(gloss, rule)
+    example['Analyzed_Word'] = analyzed_word
+    example['Gloss'] = gloss

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -202,7 +202,7 @@ class ExampleParser:
     def parse_description(self, feature_id, description):
         """Return examples in markdown description."""
         self._reset_state()
-        self.lines = unicodedata.normalize('NFKC', description).strip().splitlines()
+        self.lines = unicodedata.normalize('NFC', description).strip().splitlines()
         line = None
         _, err = self._skip_to(
             lambda ln: ln == '## Examples',

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -125,6 +125,10 @@ RE_CODING_DESC = re.compile(
     r'\b(?:coded? (?:as )?|gets a )([0-3?])', re.IGNORECASE)
 
 
+def is_coda(igt):
+    return len(igt) == 1 and len(igt[0]) > 0 and igt[0][0] == '(' and igt[-1][-1] == ')'
+
+
 class ExampleParser:
     """Parser for extracting glossed examples from markdown.
 
@@ -304,7 +308,7 @@ class ExampleParser:
                 igt.append(self._consume_line())
         if line is None:
             errors.append(ParseError(f'{feature_id}:{language_id}: unfinished example block'))
-        elif igt:
+        elif igt and not is_coda(igt):
             errors.append(ParseError(f'{feature_id}:{self.cursor+1}:{language_id}: expected translation'))
         return examples, errors
 

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -1,4 +1,27 @@
-from collections import namedtuple
+import unicodedata
+from collections import defaultdict, namedtuple
+from itertools import zip_longest
+
+
+class ParseError(namedtuple('ParseError', 'msg')):
+    def __str__(self):
+        return self.msg
+
+
+def example_error_msg(example, msg):
+    if (debug_info := example.get('Debug_Info')):
+        return f'{debug_info}: {msg}'
+    else:
+        return msg
+
+
+def render_gloss(analyzed_word, gloss):
+    widths = [
+        max(len(wd), len(gl))
+        for wd, gl in zip_longest(analyzed_word, gloss, fillvalue='')]
+    return '  {}\n  {}'.format(
+        '  '.join(wd.ljust(w) for w, wd in zip(widths, analyzed_word)),
+        '  '.join(gl.ljust(w) for w, gl in zip(widths, gloss)))
 
 
 # Transformation rules to fix misaligned glosses
@@ -54,3 +77,81 @@ def fix_glosses(example, rules):
             gloss = apply_rule(gloss, rule)
     example['Analyzed_Word'] = analyzed_word
     example['Gloss'] = gloss
+
+
+def has_aligned_glosses(example):
+    return len(example['Analyzed_Word']) == len(example['Gloss'])
+
+
+class AlignmentChecker:
+    def __init__(self):
+        self.errors = []
+
+    def is_aligned(self, example):
+        if has_aligned_glosses(example):
+            return True
+        else:
+            err = ParseError(example_error_msg(
+                example,
+                'misaligned glosses:\n{}'.format(
+                    render_gloss(example['Analyzed_Word'], example['Gloss']))))
+            self.errors.append(err)
+            return False
+
+
+def drop_misaligned(examples):
+    checker = AlignmentChecker()
+    examples = [ex for ex in examples if checker.is_aligned(ex)]
+    return examples, checker.errors
+
+
+# Example deduplication
+#
+# This tries to detect and consolidated.  Note that the *detection* is quite
+# fuzzy but the *consolidation* requires examples to match exactly.  For
+# examples which pass the fuzzy match but not the exact match, errors will be
+# emitted.
+
+def get_unique_example_ids(examples):
+    unique = set()
+    errors = []
+
+    duplicates = defaultdict(list)
+    for example in examples:
+        primary_norm = ''.join(
+            c.lower()
+            for c in unicodedata.normalize('NFKD', example['Primary_Text'])
+            if c.isascii() and not c.isspace())
+        duplicates[example.get('Language_ID', ''), primary_norm].append(example)
+
+    for dups in duplicates.values():
+        if len(dups) < 2:
+            unique.update(ex['ID'] for ex in dups)
+        else:
+            not_duplicates = {}
+            for ex in dups:
+                key = (ex['Primary_Text'],
+                       ' '.join(ex.get('Analyzed_Word') or ()),
+                       ' '.join(ex.get('Gloss') or ()),
+                       ex.get('Translated_Text', ''))
+                if key not in not_duplicates:
+                    not_duplicates[key] = ex
+            if len(not_duplicates) != 1:
+                example_list = '\n'.join(
+                    example_error_msg(ex, "\n  {}{}\n  '{}'".format(
+                        ex['Primary_Text'],
+                        '\n{}'.format(render_gloss(ex['Analyzed_Word'], ex['Gloss'])) if ex.get('Gloss') else '',
+                        ex['Translated_Text']))
+                    for ex in dups)
+                # XXX: maybe return different error type?
+                errors.append(ParseError(f'Possible example dups:\n{example_list}'))
+            unique.update(ex['ID'] for ex in not_duplicates.values())
+
+    return unique, errors
+
+
+def unique_examples(examples):
+    unique_ids, errors = get_unique_example_ids(examples)
+    if len(unique_ids) != len(examples):
+        examples = [ex for ex in examples if ex['ID'] in unique_ids]
+    return examples, errors

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -390,7 +390,7 @@ class ExampleParser:
 
         # remove artifacts from bulleted lists
         igt = [
-            re.sub(r'^\s*(?:[a-f]\.|\([123a-e]\))\s*', '', line)
+            re.sub(r'^\s*(?:[a-f]\.|\([123a-e][a-e]?\))\s*', '', line)
             for line in igt]
 
         line_arrangement, err = arrange_example_lines(

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -233,7 +233,7 @@ class ExampleParser:
             elif line.startswith('**'):
                 examples.extend(self._parse_language(feature_id))
             else:
-                assert False, 'UNREACHABLE'  # pragma: nocover
+                raise AssertionError('UNREACHABLE')  # pragma: nocover
 
     def _parse_language(self, feature_id):
         """Return examples in a language block."""
@@ -301,7 +301,7 @@ class ExampleParser:
         elif line.startswith('```'):
             return self._parse_example_block(feature_id, language_id)
         else:
-            assert False, f'UNREACHABLE: {line}'  # pragma: nocover
+            raise AssertionError(f'UNREACHABLE: {line}')  # pragma: nocover
 
     def _parse_example_block(self, feature_id, language_id):
         """Find and parse example blocks."""
@@ -404,7 +404,7 @@ class ExampleParser:
             for ln in trlines
             for w in ln.split()
             if w)
-        example = {
+        return {
             'Language_ID': language_id,
             'Primary_Text': line_arrangement.primary_text(),
             'Analyzed_Word': line_arrangement.analyzed_word(),
@@ -412,7 +412,6 @@ class ExampleParser:
             'Translated_Text': translation.rstrip('.'),
             'Debug_Prefix': f'{feature_id}.md:line {example_lineno} ({language_id})',
         }
-        return example
 
 
 # Transformation rules to fix misaligned glosses

--- a/src/pygrambank/examples.py
+++ b/src/pygrambank/examples.py
@@ -1,13 +1,21 @@
 from collections import namedtuple
 
 
-# Rule system for fixing misaligned glosses
+# Transformation rules to fix misaligned glosses
+#
+# These rules apply after an example has been successfully parsed.  They can
+# add, remove, or change items in the Analyzed_Word or Gloss of an example.
+#
+# Beware that transformation rule change the example *in place*.
 
 GlossRule = namedtuple('GlossRule', 'pred lhs rhs')
 
 
+class MalformedRule(Exception):
+    pass
+
+
 def apply_rule_iter(items, rule):
-    assert len(rule.lhs) > 0, 'cowardly refusing to materialize items out of thin air'
     index = 0
     while index < len(items):
         rule_index = 0
@@ -26,6 +34,8 @@ def apply_rule_iter(items, rule):
 
 
 def apply_rule(items, rule):
+    if not rule.lhs:
+        raise MalformedRule('Left-hand-side of a transformation rule must not be empty')
     return list(apply_rule_iter(items, rule))
 
 

--- a/src/pygrambank/features.py
+++ b/src/pygrambank/features.py
@@ -115,7 +115,7 @@ class GB20(object):
     def _iterfeatures(self, wiki):
         # I don't want to deal with combining diacritics tbh…
         wikitext = unicodedata.normalize(
-            'NFKC',
+            'NFC',
             self.path.read_text(encoding='utf-8'))
         for chunk in wikitext.split(self.CHUNK_SEP):
             if chunk.strip():

--- a/src/pygrambank/features.py
+++ b/src/pygrambank/features.py
@@ -1,4 +1,5 @@
 import re
+import unicodedata
 from collections import OrderedDict, Counter
 
 from clldutils.misc import lazyproperty
@@ -112,7 +113,11 @@ class GB20(object):
         self.path = path
 
     def _iterfeatures(self, wiki):
-        for chunk in self.path.read_text(encoding='utf-8').split(self.CHUNK_SEP):
+        # I don't want to deal with combining diacritics tbh…
+        wikitext = unicodedata.normalize(
+            'NFKC',
+            self.path.read_text(encoding='utf-8'))
+        for chunk in wikitext.split(self.CHUNK_SEP):
             if chunk.strip():
                 yield Feature.from_chunk(chunk, wiki)
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,0 +1,135 @@
+import unittest
+
+from pygrambank import examples as gbex
+
+
+class AlignmentCorrection(unittest.TestCase):
+    def test_rule_not_applicable(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+            'Gloss': ['g1', 'g2', 'g3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'not ex1', ['m1', 'm2'], ['x1', 'x2'])
+        gbex.fix_glosses(example, [rule])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+        self.assertEqual(example['Analyzed_Word'], ['m1', 'm2', 'm3'])
+        self.assertEqual(example['Gloss'], ['g1', 'g2', 'g3'])
+
+    def test_example_is_zero(self):
+        example = {}
+        rule = gbex.GlossRule(lambda _: True, ['m1', 'm2'], ['x1', 'x2'])
+        gbex.fix_glosses(example, [rule])
+        # no mutation
+        self.assertEqual(example, {})
+
+    def test_rule_applies_but_does_not_match(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['not m1', 'not m2'], ['x1', 'x2'])
+        gbex.fix_glosses(example, [rule])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+        self.assertEqual(example['Analyzed_Word'], ['m1', 'm2', 'm3'])
+
+    def test_rule_adds_items(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m1', 'm2'], ['m1', 'm2', 'm2.5'])
+        gbex.fix_glosses(example, [rule])
+        self.assertEqual(example['Analyzed_Word'], ['m1', 'm2', 'm2.5', 'm3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+
+    def test_rule_removes_items(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m1', 'm2'], [])
+        gbex.fix_glosses(example, [rule])
+        self.assertEqual(example['Analyzed_Word'], ['m3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+
+    def test_rule_transforms_items(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m1', 'm2'], ['x1', 'x2'])
+        gbex.fix_glosses(example, [rule])
+        self.assertEqual(example['Analyzed_Word'], ['x1', 'x2', 'm3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+
+    def test_rule_applies_to_glosses(self):
+        example = {
+            'ID': 'ex1',
+            'Gloss': ['g1', 'g2', 'g3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['g1', 'g2'], ['y1', 'y2'])
+        gbex.fix_glosses(example, [rule])
+        self.assertEqual(example['Gloss'], ['y1', 'y2', 'g3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+
+    def test_rule_applies_to_multiple_examples(self):
+        example_1 = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        example_2 = {
+            'ID': 'ex2',
+            'Analyzed_Word': ['m1', 'm2', 'm4'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1' or e['ID'] == 'ex2',
+            ['m1', 'm2'], ['x1', 'x2'])
+        gbex.fix_glosses(example_1, [rule])
+        gbex.fix_glosses(example_2, [rule])
+        self.assertEqual(example_1['Analyzed_Word'], ['x1', 'x2', 'm3'])
+        self.assertEqual(example_2['Analyzed_Word'], ['x1', 'x2', 'm4'])
+        # no mutation
+        self.assertEqual(example_1['ID'], 'ex1')
+        self.assertEqual(example_2['ID'], 'ex2')
+
+    def test_multiple_rules_apply_to_example(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        transform_m1_m2 = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m1', 'm2'], ['x1', 'x2'])
+        transform_m3 = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m3'], ['x3'])
+        gbex.fix_glosses(example, [transform_m1_m2, transform_m3])
+        self.assertEqual(example['Analyzed_Word'], ['x1', 'x2', 'x3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+
+    def test_rule_order_matters(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        # just a simple example for bleeding
+        transform_m1_m2 = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m1', 'm2'], ['x1', 'x2'])
+        transform_m2 = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', ['m2'], ['not x2'])
+        gbex.fix_glosses(example, [transform_m1_m2, transform_m2])
+        self.assertEqual(example['Analyzed_Word'], ['x1', 'x2', 'm3'])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -556,6 +556,28 @@ class ExampleExtraction(unittest.TestCase):
         self.assertEqual(ex2['Translated_Text'], 'Martin reads a book in the library')
         self.assertEqual(errors, [])
 
+    def test_ignore_note_at_the_end(self):
+        wikipage = '\n'.join([
+            '## Examples',
+            '**Saxon** (Glottolog: uppe1465)',
+            '```',
+            'der  mehrt         ega',
+            'DEM  take.forever  constantly',
+            '‘he always takes forever’',
+            '',
+            '(Source: dude just trust me)',
+            '```'])
+        parser = gbex.ExampleParser([])
+        examples, errors = parser.parse_description('GB001', wikipage)
+        self.assertEqual(len(examples), 1)
+        ex = examples[0]
+        self.assertEqual(ex['Language_ID'], 'uppe1465')
+        self.assertEqual(ex['Primary_Text'], 'der mehrt ega')
+        self.assertEqual(ex['Analyzed_Word'], ['der', 'mehrt', 'ega'])
+        self.assertEqual(ex['Gloss'], ['DEM', 'take.forever', 'constantly'])
+        self.assertEqual(ex['Translated_Text'], 'he always takes forever')
+        self.assertEqual(errors, [])
+
 
 class AlignmentCorrection(unittest.TestCase):
 

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -4,6 +4,7 @@ from pygrambank import examples as gbex
 
 
 class AlignmentCorrection(unittest.TestCase):
+
     def test_rule_not_applicable(self):
         example = {
             'ID': 'ex1',
@@ -33,6 +34,19 @@ class AlignmentCorrection(unittest.TestCase):
         rule = gbex.GlossRule(
             lambda e: e['ID'] == 'ex1', ['not m1', 'not m2'], ['x1', 'x2'])
         gbex.fix_glosses(example, [rule])
+        # no mutation
+        self.assertEqual(example['ID'], 'ex1')
+        self.assertEqual(example['Analyzed_Word'], ['m1', 'm2', 'm3'])
+
+    def test_rule_lacks_lhs(self):
+        example = {
+            'ID': 'ex1',
+            'Analyzed_Word': ['m1', 'm2', 'm3'],
+        }
+        rule = gbex.GlossRule(
+            lambda e: e['ID'] == 'ex1', [], ['one million euros in my bank account'])
+        with self.assertRaises(gbex.MalformedRule):
+            gbex.fix_glosses(example, [rule])
         # no mutation
         self.assertEqual(example['ID'], 'ex1')
         self.assertEqual(example['Analyzed_Word'], ['m1', 'm2', 'm3'])

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -888,14 +888,18 @@ class ExampleDeduplication(unittest.TestCase):
     def test_no_duplicates(self):
         examples = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'an example'},
             {'ID': 'ex2',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'a second example'}]
         # nothing happened
         expected = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'an example'},
             {'ID': 'ex2',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'a second example'}]
         result, errors = gbex.unique_examples(examples)
         self.assertEqual(errors, [])
@@ -904,11 +908,14 @@ class ExampleDeduplication(unittest.TestCase):
     def test_exact_duplicates(self):
         examples = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'the same example'},
             {'ID': 'ex2',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'the same example'}]
         expected = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'the same example'}]
         result, errors = gbex.unique_examples(examples)
         self.assertEqual(errors, [])
@@ -936,52 +943,62 @@ class ExampleDeduplication(unittest.TestCase):
     def test_fuzzy_duplicates(self):
         examples = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'FAST dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'das-selbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost(!!!) the same'}]
         expected = [
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'FAST dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'das-selbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],
              'Translated_Text': 'Almost the same'},
             {'ID': 'ex1',
+             'Language_ID': 'stan1293',
              'Primary_Text': 'Fast dasselbe',
              'Analyzed_Word': ['fast', 'dasselbe'],
              'Gloss': ['almost', 'the.same'],

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -107,8 +107,9 @@ class ExampleExtraction(unittest.TestCase):
 
     def test_no_example_sections(self):
         wikipage = 'No examples here, sir'
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -118,8 +119,9 @@ class ExampleExtraction(unittest.TestCase):
             'hi',
             '## Examples',
             'hi again'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -131,8 +133,9 @@ class ExampleExtraction(unittest.TestCase):
             'hi again',
             '## No Examples either',
             'how are you doing today?'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(errors, [])
 
@@ -140,8 +143,9 @@ class ExampleExtraction(unittest.TestCase):
         wikipage = '\n'.join([
             '## Examples',
             'hi'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(errors, [])
 
@@ -149,8 +153,9 @@ class ExampleExtraction(unittest.TestCase):
         wikipage = '\n'.join([
             '## Examples',
             '**Saxon** (Glottolog: upp1465)'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -158,8 +163,9 @@ class ExampleExtraction(unittest.TestCase):
         wikipage = '\n'.join([
             '## Examples',
             '**Saxon** (Glottolog: uppe1465)'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -174,8 +180,9 @@ class ExampleExtraction(unittest.TestCase):
             'Coded 1.',
             '',
             '## Next section'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(errors, [])
 
@@ -185,8 +192,9 @@ class ExampleExtraction(unittest.TestCase):
             '**Saxon** (Glottolog: uppe1465)',
             '',
             'Coded 1.'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertNotEqual(errors, [])
 
@@ -198,8 +206,9 @@ class ExampleExtraction(unittest.TestCase):
             'Coded 1.',
             '',
             'hi'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertNotEqual(errors, [])
 
@@ -212,8 +221,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -233,8 +243,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -253,8 +264,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’',
             '## next section'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertNotEqual(errors, [])
 
@@ -267,8 +279,9 @@ class ExampleExtraction(unittest.TestCase):
             '‘he always takes forever’',
             '```',
             '## next section'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -280,8 +293,9 @@ class ExampleExtraction(unittest.TestCase):
             '‘he always takes forever’',
             '```',
             '## next section'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -294,8 +308,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '```',
             '## next section'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(examples, [])
         self.assertEqual(len(errors), 1)
 
@@ -309,8 +324,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -331,8 +347,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -351,8 +368,9 @@ class ExampleExtraction(unittest.TestCase):
             'DEM  take.forever  constantly',
             '‘he always takes forever’ (roughly)',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -374,8 +392,9 @@ class ExampleExtraction(unittest.TestCase):
             'forever’ (wow, what a',
             'tense build-up)',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -395,8 +414,9 @@ class ExampleExtraction(unittest.TestCase):
             "‘he always takes forever’ OR ‘something else’",
             'OOOR ‘yet another thing’!',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -420,8 +440,9 @@ class ExampleExtraction(unittest.TestCase):
             'well  look   for.a.bit  a  ladybird',
             '‘Would you look at that, a ladybird’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 2)
         ex1 = examples[0]
         self.assertEqual(ex1['Language_ID'], 'uppe1465')
@@ -449,8 +470,9 @@ class ExampleExtraction(unittest.TestCase):
             'nu    gugge  ma,        e  Motschegiebschn',
             '‘Would you look at that, a ladybird’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex1 = examples[0]
         self.assertEqual(ex1['Language_ID'], 'uppe1465')
@@ -473,8 +495,9 @@ class ExampleExtraction(unittest.TestCase):
             '    well  look   for.a.bit  a  ladybird',
             '    ‘Would you look at that, a ladybird’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 2)
         ex1 = examples[0]
         self.assertEqual(ex1['Language_ID'], 'uppe1465')
@@ -507,8 +530,9 @@ class ExampleExtraction(unittest.TestCase):
             'well  look   for.a.bit  a  ladybird',
             '‘Would you look at that, a ladybird’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 2)
         ex1 = examples[0]
         self.assertEqual(ex1['Language_ID'], 'uppe1465')
@@ -539,8 +563,9 @@ class ExampleExtraction(unittest.TestCase):
             'Martin  reads  book   in  library',
             '‘Martin reads a book in the library’',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 2)
         ex1 = examples[0]
         self.assertEqual(ex1['Language_ID'], 'uppe1465')
@@ -556,6 +581,36 @@ class ExampleExtraction(unittest.TestCase):
         self.assertEqual(ex2['Translated_Text'], 'Martin reads a book in the library')
         self.assertEqual(errors, [])
 
+    def test_blacklist(self):
+        wikipage = '\n'.join([
+            '## Examples',
+            '**Saxon** (Glottolog: uppe1465)',
+            '```',
+            'der  mehrt         ega',
+            'DEM  take.forever  constantly',
+            '‘he always takes forever’',
+            '```',
+            '**Upper Sorbian** (Glottolog: uppe1395)',
+            '```',
+            '   | SG            | DU          | PL        ',
+            '---+---------------+-------------+-----------',
+            ' 1 | ja            | mój         | my        ',
+            ' 2 | ty            | wój         | wy        ',
+            ' 3 | wón/wona/wone | wonaj/wonej | woni/wone ',
+            '```'])
+        blacklist = [('GB001', 'uppe1395')]
+        parser = gbex.ExampleParser([], blacklist)
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
+        self.assertEqual(len(examples), 1)
+        ex = examples[0]
+        self.assertEqual(ex['Language_ID'], 'uppe1465')
+        self.assertEqual(ex['Primary_Text'], 'der mehrt ega')
+        self.assertEqual(ex['Analyzed_Word'], ['der', 'mehrt', 'ega'])
+        self.assertEqual(ex['Gloss'], ['DEM', 'take.forever', 'constantly'])
+        self.assertEqual(ex['Translated_Text'], 'he always takes forever')
+        self.assertEqual(errors, [])
+
     def test_ignore_note_at_the_end(self):
         wikipage = '\n'.join([
             '## Examples',
@@ -567,8 +622,9 @@ class ExampleExtraction(unittest.TestCase):
             '',
             '(Source: dude just trust me)',
             '```'])
-        parser = gbex.ExampleParser([])
-        examples, errors = parser.parse_description('GB001', wikipage)
+        parser = gbex.ExampleParser([], [])
+        examples = parser.parse_description('GB001', wikipage)
+        errors = parser.errors()
         self.assertEqual(len(examples), 1)
         ex = examples[0]
         self.assertEqual(ex['Language_ID'], 'uppe1465')
@@ -577,6 +633,52 @@ class ExampleExtraction(unittest.TestCase):
         self.assertEqual(ex['Gloss'], ['DEM', 'take.forever', 'constantly'])
         self.assertEqual(ex['Translated_Text'], 'he always takes forever')
         self.assertEqual(errors, [])
+
+    def test_parser_reuse_and_error_collection(self):
+        parser = gbex.ExampleParser([], [])
+        wikipage1 = '\n'.join([
+            '## Examples',
+            '**Saxon** (Glottolog: uppe1465)',
+            '```',
+            'a.  der  mehrt         ega',
+            '    DEM  take.forever  constantly',
+            '    ‘he always takes forever’',
+            '',
+            'b.  nu    gugge  ma,        e  Motschegiebschn',
+            '    well  look   for.a.bit  a  ladybird',
+            '```'])
+        examples1 = parser.parse_description('GB001', wikipage1)
+        wikipage2 = '\n'.join([
+            '## Examples',
+            '**Upper Sorbian** (Glottolog: uppe1395)',
+            '```',
+            'a. Měrćin  čita   knihu  w   bibliotece',
+            '   Martin  reads  book   in  library',
+            '   ‘Martin reads a book in the library’',
+            '',
+            'b. Měrćin  čita   knihu  wo     wjelrybach',
+            '   Martin  reads  book   about  whales',
+            '```'])
+        examples2 = parser.parse_description('GB001', wikipage2)
+
+        self.assertEqual(len(examples1), 1)
+        ex1 = examples1[0]
+        self.assertEqual(ex1['Language_ID'], 'uppe1465')
+        self.assertEqual(ex1['Primary_Text'], 'der mehrt ega')
+        self.assertEqual(ex1['Analyzed_Word'], ['der', 'mehrt', 'ega'])
+        self.assertEqual(ex1['Gloss'], ['DEM', 'take.forever', 'constantly'])
+        self.assertEqual(ex1['Translated_Text'], 'he always takes forever')
+
+        self.assertEqual(len(examples2), 1)
+        ex2 = examples2[0]
+        self.assertEqual(ex2['Language_ID'], 'uppe1395')
+        self.assertEqual(ex2['Primary_Text'], 'Měrćin čita knihu w bibliotece')
+        self.assertEqual(ex2['Analyzed_Word'], ['Měrćin', 'čita', 'knihu', 'w', 'bibliotece'])
+        self.assertEqual(ex2['Gloss'], ['Martin', 'reads', 'book', 'in', 'library'])
+        self.assertEqual(ex2['Translated_Text'], 'Martin reads a book in the library')
+
+        errors = parser.errors()
+        self.assertEqual(len(errors), 2)
 
 
 class AlignmentCorrection(unittest.TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{38,39,310,311,312}
+envlist = py{38,39,310,311,312,313}
 skip_missing_interpreters = true
 
 [testenv]


### PR DESCRIPTION
So, here's the code for extracting examples from the grambank wiki (see <https://github.com/grambank/grambank/issues/58>).  The usage code in the *cldfbench* is gonna live in a local branch on my laptop until gb2.0 is publicly released.

Things that could be added in the future (ordered by perceived complexity from easy to hard):

 * Add an example table to the web app
 * Linking examples to the value table.
 * Finding mentions of the feature value and double-check them against the value table as a sanity check.
 * Finding sources and trying to match them against.
 * Using cldf-markdown to make examples clickable on the web app.

@hedvigs Once this is merged, I'd make an updated release candidate (the value table hasn't changed, as we agreed).
